### PR TITLE
feat: migrate ingress from NGINX to Envoy Gateway

### DIFF
--- a/deploy/backend-values.yaml
+++ b/deploy/backend-values.yaml
@@ -66,21 +66,15 @@ service:
   port: 8000
   targetPort: 8000
 
-# Ingress for API (optional - can be internal only if frontend proxies)
-ingress:
+# Gateway API (Envoy Gateway) - replaces ingress-nginx
+# Creates an HTTPRoute pointing to the shared dataportal-gateway
+# TLS is managed at the shared Gateway level (not per-application)
+gateway:
   enabled: true
-  className: nginx
-  annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  hosts:
-  - host: api.application-evaluator.dataportal.fi
-    paths:
-    - path: /
-      pathType: ImplementationSpecific
-  tls:
-  - hosts:
-    - api.application-evaluator.dataportal.fi
-    secretName: application-evaluator-backend-tls # pragma: allowlist secret
+
+# Ingress disabled - using Gateway API instead (mutually exclusive with gateway)
+ingress:
+  enabled: false
 
 # Health checks
 livenessProbe:

--- a/deploy/frontend-values.yaml
+++ b/deploy/frontend-values.yaml
@@ -51,21 +51,15 @@ service:
   port: 80
   targetPort: 80
 
-# Ingress for frontend
-ingress:
+# Gateway API (Envoy Gateway) - replaces ingress-nginx
+# Creates an HTTPRoute pointing to the shared dataportal-gateway
+# TLS is managed at the shared Gateway level (not per-application)
+gateway:
   enabled: true
-  className: nginx
-  annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  hosts:
-  - host: application-evaluator.dataportal.fi
-    paths:
-    - path: /
-      pathType: ImplementationSpecific
-  tls:
-  - hosts:
-    - application-evaluator.dataportal.fi
-    secretName: application-evaluator-frontend-tls # pragma: allowlist secret
+
+# Ingress disabled - using Gateway API instead (mutually exclusive with gateway)
+ingress:
+  enabled: false
 
 # Health checks
 livenessProbe:


### PR DESCRIPTION
Migrates ApplicationEvaluator from ingress-nginx to Envoy Gateway (Gateway API) for both backend and frontend services.

## Changes
- Add `gateway: enabled: true` to `deploy/backend-values.yaml`
- Add `gateway: enabled: true` to `deploy/frontend-values.yaml`
- Disable ingress (mutually exclusive with gateway)
- Remove NGINX-specific ingress configuration (className, annotations, TLS)

Closes #68

Generated with [Claude Code](https://claude.ai/code)